### PR TITLE
Main.hs: tweak for optparse-applicative-0.13

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -5,6 +6,9 @@
 module Main where
 import System.Process
 import Control.Monad.Identity
+#if MIN_VERSION_optparse_applicative(0,13,0)
+import Data.Monoid ((<>))
+#endif
 import Data.Yaml hiding (Parser)
 import Data.Yaml.Config
 import qualified Data.Map as M


### PR DESCRIPTION
OA 0.13 stopped reexporting own (<>) operator
in favor of Data.Monoid one.

That led to the following build error:

  Main.hs:40:115: error:
    • Variable not in scope:
        (<>) :: Parser Command -> Mod CommandFields Command -> t3
    • Perhaps you meant one of these:
        ‘<*>’ (imported from Prelude), ‘<$>’ (imported from Prelude),
        ‘<|>’ (imported from Options.Applicative)

Signed-off-by: Sergei Trofimovich <siarheit@google.com>