### PR TITLE
convert compiler value to a string

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -149,7 +149,7 @@ configure = do
   log "Creating shell.nix file"
   writeFile ".styx/shell.nix" $ unlines $
     ["{ nixpkgs ? import <nixpkgs> {}"
-    , maybe "" (", compiler ? " ++) cfgDefCompil
+    , maybe "" ((", compiler ? " ++) . show) cfgDefCompil
     ," }:"]
     ++ case cfgNixpkgsVersion of
       Nothing -> ["let nixpkgs' = nixpkgs;"]


### PR DESCRIPTION
Fixes the problem where compiler argument passed as a symbol not a string.

before:
```
{ nixpkgs ? import <nixpkgs> {}
, compiler ? ghc802
 }:
let nixpkgs' = nixpkgs;
in with nixpkgs'.pkgs;
let hp = haskell.packages.${compiler}.override{
    overrides = self: super: {
...
```

after:
```
{ nixpkgs ? import <nixpkgs> {}
, compiler ? "ghc802"
 }:
let nixpkgs' = nixpkgs;
in with nixpkgs'.pkgs;
let hp = haskell.packages.${compiler}.override{
    overrides = self: super: {
...
```